### PR TITLE
Dependabot (not on starter list) Static Tool Installation 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
##Description
Added Dependabot Tool. Used to scan chosen packages for needed updates.

##Artifacts
<img width="940" alt="Screenshot 2024-10-24 at 12 09 54 AM" src="https://github.com/user-attachments/assets/b931b09a-6bc5-490e-bff8-d798f1cb7b0e">
